### PR TITLE
added concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "serve": "vite preview"
+        "start": "concurrently \"npm:dev\" \"nodemon ./backend/index.js\""
     },
     "dependencies": {
         "axios": "^0.21.1",
@@ -34,6 +34,7 @@
     },
     "devDependencies": {
         "@vitejs/plugin-react-refresh": "^1.3.1",
+        "concurrently": "^6.2.0",
         "vite": "^2.3.0"
     }
 }


### PR DESCRIPTION
use **npm start** from now on - instead of **npm run dev**